### PR TITLE
fixed copy tooltip

### DIFF
--- a/inst/pkgdown/assets/assets/copybutton.js
+++ b/inst/pkgdown/assets/assets/copybutton.js
@@ -1,10 +1,10 @@
 /* Clipboard --------------------------*/
 
 function changeTooltipMessage(element, msg) {
-    var tooltipOriginalTitle=element.getAttribute('data-original-title');
-    element.setAttribute('data-original-title', msg);
+    var tooltipOriginalTitle=element.getAttribute('data-bs-original-title');
+    element.setAttribute('data-bs-original-title', msg);
     $(element).tooltip('show');
-    element.setAttribute('data-original-title', tooltipOriginalTitle);
+    element.setAttribute('data-bs-original-title', tooltipOriginalTitle);
   }
 
   if(ClipboardJS.isSupported()) {

--- a/source/javascripts/custom/copybutton.js
+++ b/source/javascripts/custom/copybutton.js
@@ -1,55 +1,55 @@
 /* Clipboard --------------------------*/
 
 function changeTooltipMessage(element, msg) {
-    var tooltipOriginalTitle=element.getAttribute('data-original-title');
-    element.setAttribute('data-original-title', msg);
-    $(element).tooltip('show');
-    element.setAttribute('data-original-title', tooltipOriginalTitle);
-  }
+  var tooltipOriginalTitle=element.getAttribute('data-bs-original-title');
+  element.setAttribute('data-bs-original-title', msg);
+  $(element).tooltip('show');
+  element.setAttribute('data-bs-original-title', tooltipOriginalTitle);
+}
 
-  if(ClipboardJS.isSupported()) {
-    $(document).ready(function() {
-      var copyButton = "<button";
-      var button_end = "><i class='fa fa-copy'></i> Copy </button>";
-      var tags = [
-        "type='button'",
-        "class='btn btn-primary btn-copy-ex'",
-        "type = 'submit'",
-        "title='Copy to clipboard'",
-        "aria-label='Copy to clipboard'",
-        "data-toggle='tooltip'",
-        "data-placement='right auto'",
-        "data-trigger='hover'",
-        "data-clipboard-copy",
-        "style='background-color:rgb(133, 129, 133); right: 20px; bottom: 10px; position: absolute'"
-      ]
-      $("div.sourceCode").addClass("hasCopyButton");
+if(ClipboardJS.isSupported()) {
+  $(document).ready(function() {
+    var copyButton = "<button";
+    var button_end = "><i class='fa fa-copy'></i> Copy </button>";
+    var tags = [
+      "type='button'",
+      "class='btn btn-primary btn-copy-ex'",
+      "type = 'submit'",
+      "title='Copy to clipboard'",
+      "aria-label='Copy to clipboard'",
+      "data-toggle='tooltip'",
+      "data-placement='right auto'",
+      "data-trigger='hover'",
+      "data-clipboard-copy",
+      "style='background-color:rgb(133, 129, 133); right: 20px; bottom: 10px; position: absolute'"
+    ]
+    $("div.sourceCode").addClass("hasCopyButton");
 
-      copyButton += tags.join(" ") + button_end;
+    copyButton += tags.join(" ") + button_end;
 
-      // Insert copy buttons:
-      $(copyButton).prependTo(".hasCopyButton");
+    // Insert copy buttons:
+    $(copyButton).prependTo(".hasCopyButton");
 
-      // Initialize tooltips:
-      $('.btn-copy-ex').tooltip({container: 'body'});
+    // Initialize tooltips:
+    $('.btn-copy-ex').tooltip({container: 'body'});
 
-      // Initialize clipboard:
-      var clipboardBtnCopies = new ClipboardJS('[data-clipboard-copy]', {
-        text: function(trigger) {
-          var parent = trigger.parentNode;
-          var target = parent.querySelector("code");
-          // return trigger.parentNode.textContent.replace(/\n#>[^\n]*/g, "");
-          return target.textContent.replace(/\n#>[^\n]*/g, "");
-        }
-      });
-
-      clipboardBtnCopies.on('success', function(e) {
-        changeTooltipMessage(e.trigger, 'Copied!');
-        e.clearSelection();
-      });
-
-      clipboardBtnCopies.on('error', function() {
-        changeTooltipMessage(e.trigger,'Press Ctrl+C or Command+C to copy');
-      });
+    // Initialize clipboard:
+    var clipboardBtnCopies = new ClipboardJS('[data-clipboard-copy]', {
+      text: function(trigger) {
+        var parent = trigger.parentNode;
+        var target = parent.querySelector("code");
+        // return trigger.parentNode.textContent.replace(/\n#>[^\n]*/g, "");
+        return target.textContent.replace(/\n#>[^\n]*/g, "");
+      }
     });
-  }
+
+    clipboardBtnCopies.on('success', function(e) {
+      changeTooltipMessage(e.trigger, 'Copied!');
+      e.clearSelection();
+    });
+
+    clipboardBtnCopies.on('error', function() {
+      changeTooltipMessage(e.trigger,'Press Ctrl+C or Command+C to copy');
+    });
+  });
+}


### PR DESCRIPTION
Fixed copy button in code blocks to display tooltip that says "Copied!" when code successfully copied to clipboard

Before click, hovering over button: 
![image](https://github.com/user-attachments/assets/0ea4404d-d704-4f43-8fef-7093d48f0de9)
After click:
![image](https://github.com/user-attachments/assets/c42d97b7-03d7-4917-b778-5345e252bbb8)
